### PR TITLE
Fixes for v10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,45 @@
+name: Release Creation
+
+on: 
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    # get part of the tag after the `v`
+    - name: Extract tag version number
+      id: get_version
+      uses: battila7/get-version-action@v2
+
+    # Substitute the Manifest and Download URLs in the module.json
+    - name: Substitute Manifest and Download Links For Versioned Ones
+      id: sub_manifest_link_version
+      uses: microsoft/variable-substitution@v1
+      with:
+        files: 'module.json'
+      env:
+        version: ${{steps.get_version.outputs.version-without-v}}
+        url: https://github.com/${{github.repository}}
+        manifest: https://github.com/${{github.repository}}/releases/latest/download/module.json
+        download: https://github.com/${{github.repository}}/releases/download/${{github.event.release.tag_name}}/module.zip
+
+    # Create a zip file with all files required by the module to add to the release
+    - run: zip -r ./module.zip module.json gm-notes.js gm-notes.css templates.html patchnotes.md README.md lang/ packs/
+
+    # Create a release for this specific version
+    - name: Update Release with Files
+      id: create_version_release
+      uses: ncipollo/release-action@v1
+      with:
+        allowUpdates: true # Set this to false if you want to prevent updating existing releases
+        name: ${{ github.event.release.name }}
+        draft: ${{ github.event.release.unpublished }}
+        prerelease: ${{ github.event.release.prerelease }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        artifacts: './module.json, ./module.zip'
+        tag: ${{ github.event.release.tag_name }}
+        body: ${{ github.event.release.body }}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This module is system independent, but has an additional feature to easily move 
 ## Contribution
 French Translation by baktov#773, Japanese translation by Brother Sharp#6921
 
-This version is maintained by Bithir, but if you feel like tupping the original creator, do that at paypal felix.mueller.86@web.de
+If you feel like supporting my work, feel free to leave a tip at my paypal felix.mueller.86@web.de
 
 ## License
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons Licence" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" property="dct:title">GM Notes - a module for Foundry VTT -</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://github.com/syl3r86?tab=repositories" property="cc:attributionName" rel="cc:attributionURL">Felix Müller</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This module is system independent, but has an additional feature to easily move 
 ## Contribution
 French Translation by baktov#773, Japanese translation by Brother Sharp#6921
 
-If you feel like supporting my work, feel free to leave a tip at my paypal felix.mueller.86@web.de
+This version is maintained by Bithir, but if you feel like tupping the original creator, do that at paypal felix.mueller.86@web.de
 
 ## License
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons Licence" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" property="dct:title">GM Notes - a module for Foundry VTT -</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://github.com/syl3r86?tab=repositories" property="cc:attributionName" rel="cc:attributionURL">Felix Müller</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,23 @@
 # GM Notes
 
-A Foundry VTT Module to add GM-Only notes to entities (Actor, Items (including owned items), RollTable and JournalEntry).
-This module is system independent, but has an additional feature to easily move GM notes to or from the actors bio, items description or JournalEntrys content.
+A Foundry VTT Module to add GM-Only notes to entities (Actor, Items (including owned items), Tiles, Light, Drawings, RollTable and JournalEntry).
+This module is system independent, but has an additional feature to easily move GM notes to or from the actors bio, items description or JournalEntrys content for the dnd5e system.
 
 ## Installation
 1. Copy this link and use it in Foundrys Module Manager to install the Module
 
-    > https://raw.githubusercontent.com/syl3r86/gm-notes/master/module.json
+    > https://github.com/bithir/gm-notes/releases/latest/download/module.json
     
 2. Enable the Module in your Worlds Module Settings
 
 ## Contribution
+A massive thanks to the original author Felix Müller (syl3r86 - Paypal: felix.mueller.86@web.de)
 French Translation by baktov#773, Japanese translation by Brother Sharp#6921
 
-If you feel like supporting my work, feel free to leave a tip at my paypal felix.mueller.86@web.de
 
 ## License
-<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons Licence" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" property="dct:title">GM Notes - a module for Foundry VTT -</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://github.com/syl3r86?tab=repositories" property="cc:attributionName" rel="cc:attributionURL">Felix Müller</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.
+<a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons Licence" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" property="dct:title">GM Notes - a module for Foundry VTT -</span> originally created by <a xmlns:cc="http://creativecommons.org/ns#" href="https://github.com/syl3r86?tab=repositories" property="cc:attributionName" rel="cc:attributionURL">Felix Müller</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>. 
+
+Current maintainer is <a xmlns:cc="http://creativecommons.org/ns#" href="https://github.com/bithir?tab=repositories" property="cc:attributionName" rel="cc:attributionURL">Peter Norell (Bithir)</a>.
 
 This work is licensed under Foundry Virtual Tabletop [EULA - Limited License Agreement for module development v 0.3.8](http://foundryvtt.com/pages/license.html).

--- a/devmessage.js
+++ b/devmessage.js
@@ -1,0 +1,36 @@
+
+export function sendDevMessage() 
+{
+    if( game.user.isGM ) {
+        let jqxhr = $.getJSON( "https://raw.githubusercontent.com/bithir/gm-notes/master/msgdata/data.json", function(data) 
+        {                    
+            let latestVersion = game.settings.get("gm-notes", 'devMessageVersionNumber');
+            if(isNaN(latestVersion)) {
+                latestVersion = 0;
+            }
+            if(data.messages === undefined || data.messages === null || data.messages.length === undefined) {
+                return;
+            }
+
+            for(let i = 0; i < data.messages.length; i++)
+            {
+                let msgenvelope = data.messages[i];
+                if( msgenvelope.version > latestVersion )
+                {
+                    ChatMessage.create(
+                    {
+                        speaker: ChatMessage.getSpeaker({alias: "GM Notes News"}),
+                        whisper: [game.user],
+                        content: msgenvelope.message        
+                    });        
+                }
+                latestVersion = Math.max(latestVersion, msgenvelope.version);
+            }
+            console.log("Message system - latestVersion message after "+latestVersion);
+            game.settings.set("gm-notes", 'devMessageVersionNumber', latestVersion);
+        })
+        .fail(function(data) {
+            console.error("Could not retreive GM Notes mods news Message:"+JSON.stringify(data));
+        });
+    }    
+}

--- a/gm-notes.css
+++ b/gm-notes.css
@@ -10,3 +10,7 @@
     width: 48%;
     margin-bottom: 6px;
 }
+
+.gm-notes .gm-notesform {
+    height:100%;
+}

--- a/gm-notes.js
+++ b/gm-notes.js
@@ -24,9 +24,14 @@ class GMNote extends FormApplication {
     async getData() {
         const data = super.getData();
 
-        // Current page is on another event loop - wait for 50 millis solves it in majority of circumstances
-        await this.sleep(50);
-        let page = this.getCurrentPage();
+    
+        let page = null;
+        if(this.object.constructor.name === 'JournalEntry') 
+        {
+            // Current page is on another event loop - wait for 50 millis solves it in majority of circumstances
+            await this.sleep(50);
+            page = this.getCurrentPage();
+        }
 
         data.journalNotes = await TextEditor.enrichHTML(this.object.getFlag('gm-notes', 'notes'), { async:true});
 
@@ -40,6 +45,9 @@ class GMNote extends FormApplication {
 
     getCurrentPage()
     {
+        if(this.object.constructor.name === 'JournalEntry') { 
+            return null;
+        }
         // Find current page
         let pageIdentifier = $(this.object.sheet.pagesInView[0]).data("pageId");
 

--- a/gm-notes.js
+++ b/gm-notes.js
@@ -29,12 +29,12 @@ class GMNote extends FormApplication {
         if(this.object.constructor.name === 'JournalEntry') 
         {
             // Current page is on another event loop - wait for 50 millis solves it in majority of circumstances
-            await this.sleep(50);
+            await this.sleep(100);
             page = this.getCurrentPage();
         }
 
-        data.journalNotes = await TextEditor.enrichHTML(this.object.getFlag('gm-notes', 'notes'), { async:true});
 
+        data.journalNotes = await TextEditor.enrichHTML(this.object.getFlag('gm-notes', 'notes'), { async:true});
         data.flags = this.object.flags;
         data.owner = game.user.id;
         data.isGM = game.user.isGM;
@@ -45,7 +45,7 @@ class GMNote extends FormApplication {
 
     getCurrentPage()
     {
-        if(this.object.constructor.name === 'JournalEntry') { 
+        if(this.object.constructor.name !== 'JournalEntry') { 
             return null;
         }
         // Find current page
@@ -69,9 +69,12 @@ class GMNote extends FormApplication {
     }
     
     async _updateObject(event, formData) {
+        if (jQuery.isEmptyObject(formData) ) {
+            return;
+        }
         if (game.user.isGM) {
             await this.object.setFlag('gm-notes', 'notes', formData["flags.gm-notes.notes"]);
-            this.render();
+            // this.render();
         } else {
             ui.notifications.error("You have to be GM to edit GM Notes.");
         }
@@ -180,6 +183,7 @@ class GMNote extends FormApplication {
         }
     }
 }
+
 Hooks.on('init', () => {
     game.settings.register("gm-notes", 'hideLabel', {
         name: game.i18n.localize('GMNote.setting'),
@@ -208,5 +212,14 @@ Hooks.on('renderJournalSheet', (app, html, data) => {
     GMNote._initEntityHook(app, html, data);
 });
 Hooks.on('renderRollTableConfig', (app, html, data) => {
+    GMNote._initEntityHook(app, html, data);
+});
+Hooks.on('renderTileConfig', (app, html, data) => {
+    GMNote._initEntityHook(app, html, data);
+});
+Hooks.on('renderDrawingConfig', (app, html, data) => {
+    GMNote._initEntityHook(app, html, data);
+});
+Hooks.on('renderAmbientLightConfig', (app, html, data) => {
     GMNote._initEntityHook(app, html, data);
 });

--- a/gm-notes.js
+++ b/gm-notes.js
@@ -200,6 +200,14 @@ Hooks.on('init', () => {
         default: false,
         type: Boolean
     });
+    game.settings.register("gm-notes", 'devMessageVersionNumber', {
+        name: 'Development message version',
+        scope: 'world',
+        config: false,
+        type: String,
+        default: '0',
+    });
+
 });
 
 Hooks.on('renderActorSheet', (app, html, data) => {

--- a/gm-notes.js
+++ b/gm-notes.js
@@ -1,3 +1,4 @@
+import { sendDevMessage } from './devmessage.js';
 class GMNote extends FormApplication {
 
     constructor(object, options) {
@@ -184,7 +185,7 @@ class GMNote extends FormApplication {
     }
 }
 
-Hooks.on('init', () => {
+Hooks.once('init', () => {
     game.settings.register("gm-notes", 'hideLabel', {
         name: game.i18n.localize('GMNote.setting'),
         hint: game.i18n.localize('GMNote.settingHint'),
@@ -208,6 +209,13 @@ Hooks.on('init', () => {
         default: '0',
     });
 
+});
+
+Hooks.once('ready', async function() {
+    if (game.user.isGM) {
+        sendDevMessage();
+    }
+    console.info(`gm-notes | Module[gm-notes] ready hook complete`);
 });
 
 Hooks.on('renderActorSheet', (app, html, data) => {

--- a/module.json
+++ b/module.json
@@ -6,8 +6,15 @@
 	"version": "0.6.0",
   "authors": [
     {
-      "name": "Felix#6196"
+      "name": "Felix#6196",
+      "comment": "Original Author"
+    },
+    {
+      "name": "Bithir",
+      "email": "bithir@gmail.com",
+      "website": "https://bithir.co.uk/",
     }
+
   ],
   "minimumCoreVersion": 10,
   "compatibleCoreVersion": 10,

--- a/module.json
+++ b/module.json
@@ -2,19 +2,18 @@
 	"name": "gm-notes",
   "id": "gm-notes",
 	"title": "GM Notes",
-	"description": "Adds the option to create Notes for Actors, Items and JournalEntrys only accessible to GMs",
-	"version": "0.6.0",
+	"description": "Adds the option to create Notes for Actors, Items, Lights, Tiles, Drawings and JournalEntrys only accessible to GMs",
+	"version": "0.7.0",
   "authors": [
-    {
-      "name": "Felix#6196",
-      "comment": "Original Author"
-    },
     {
       "name": "Bithir",
       "email": "bithir@gmail.com",
       "website": "https://bithir.co.uk/"
+    },    
+    {
+      "name": "Felix#6196",
+      "comment": "Original Author"
     }
-
   ],
   "minimumCoreVersion": 10,
   "compatibleCoreVersion": 10,
@@ -23,7 +22,10 @@
     "verified": 10,
     "maximum": 10
   },
-	"scripts": ["./gm-notes.js"],
+  "esmodules": [
+    "./gm-notes.js"
+  ],
+	"scripts": [],
 	"styles": ["./gm-notes.css"],
   "languages": [
       {

--- a/module.json
+++ b/module.json
@@ -25,29 +25,30 @@
   },
 	"scripts": ["./gm-notes.js"],
 	"styles": ["./gm-notes.css"],
-    "url": "https://github.com/syl3r86/gm-notes",
-    "manifest": "https://raw.githubusercontent.com/syl3r86/gm-notes/master/module.json",
-    "download": "https://github.com/syl3r86/gm-notes/archive/master.zip",
-    "languages": [
-        {
-          "lang": "en",
-          "name": "English",
-          "path": "lang/en.json"
-        },
-        {
-          "lang": "ja",
-          "name": "Japanese",
-          "path": "lang/ja.json"
-        },
-        {
-          "lang": "de",
-          "name": "German",
-          "path": "lang/de.json"
-        },
-        {
-          "lang": "fr",
-          "name": "French (FRANCE)",
-          "path": "lang/fr.json"
-        }
-    ]
+  "languages": [
+      {
+        "lang": "en",
+        "name": "English",
+        "path": "lang/en.json"
+      },
+      {
+        "lang": "ja",
+        "name": "Japanese",
+        "path": "lang/ja.json"
+      },
+      {
+        "lang": "de",
+        "name": "German",
+        "path": "lang/de.json"
+      },
+      {
+        "lang": "fr",
+        "name": "French (FRANCE)",
+        "path": "lang/fr.json"
+      }
+  ],
+  "url": "This is auto replaced",
+  "manifest": "This is auto replaced",
+  "download": "This is auto replaced"
+
 }

--- a/module.json
+++ b/module.json
@@ -47,8 +47,8 @@
         "path": "lang/fr.json"
       }
   ],
-  "url": "This is auto replaced",
-  "manifest": "This is auto replaced",
-  "download": "This is auto replaced"
+  "url": "https://github.com/syl3r86/gm-notes",
+  "manifest": "https://raw.githubusercontent.com/syl3r86/gm-notes/master/module.json",
+  "download": "https://github.com/syl3r86/gm-notes/archive/master.zip"
 
 }

--- a/module.json
+++ b/module.json
@@ -1,9 +1,21 @@
 {
 	"name": "gm-notes",
+  "id": "gm-notes",
 	"title": "GM Notes",
 	"description": "Adds the option to create Notes for Actors, Items and JournalEntrys only accessible to GMs",
-	"version": "0.5.0",
-	"author": "Felix#6196",
+	"version": "0.6.0",
+  "authors": [
+    {
+      "name": "Felix#6196"
+    }
+  ],
+  "minimumCoreVersion": 10,
+  "compatibleCoreVersion": 10,
+  "compatibility": {
+    "minimum": 10,
+    "verified": 10,
+    "maximum": 10
+  },
 	"scripts": ["./gm-notes.js"],
 	"styles": ["./gm-notes.css"],
     "url": "https://github.com/syl3r86/gm-notes",
@@ -30,7 +42,5 @@
           "name": "French (FRANCE)",
           "path": "lang/fr.json"
         }
-    ],
-    "minimumCoreVersion": "0.5.5",
-    "compatibleCoreVersion": "9.238"
+    ]
 }

--- a/module.json
+++ b/module.json
@@ -12,7 +12,7 @@
     {
       "name": "Bithir",
       "email": "bithir@gmail.com",
-      "website": "https://bithir.co.uk/",
+      "website": "https://bithir.co.uk/"
     }
 
   ],

--- a/msgdata/data.json
+++ b/msgdata/data.json
@@ -1,0 +1,8 @@
+{
+    "messages": [
+        {
+            "version":1,
+            "message":"<h1>Welcome to GM Notes</h1><br />This module allows you to put GM notes on most of the things in Foundry, including actors, lights, journals, items"
+        }
+    ]
+}

--- a/patchnotes.md
+++ b/patchnotes.md
@@ -1,3 +1,5 @@
+v0.6.0
+
 
 v0.5.0
  - fixed compability with Foundry version 9

--- a/patchnotes.md
+++ b/patchnotes.md
@@ -1,5 +1,18 @@
-v0.6.0
+v7.0
 
+Initial release after shifting module responsibility. Bithir is now the new maintainer.
+Added message system, so that it is possible to notify game owners if there are any particular issues with the current release.
+
+v6.02
+
+Minor fixes plus solution for #25 and [Feature Request] Identifier for items with GM notes.  #29
+
+v6.01
+
+- Yaml changes
+
+v0.6.0
+ - Initial v10 support
 
 v0.5.0
  - fixed compability with Foundry version 9

--- a/templates.html
+++ b/templates.html
@@ -1,4 +1,4 @@
-<form class="editable">
+<form class="editable gm-notesform">
     {{#if isGM}}    
         {{#if showExtraButtons}}
             <div class="controlls">

--- a/templates.html
+++ b/templates.html
@@ -6,6 +6,6 @@
                 <button class="moveToDescription">{{localize "GMNote.moveToDescription"}}</button>
             </div>
         {{/if}}
-        {{editor content=flags.gm-notes.notes target="flags.gm-notes.notes" button=true owner=owner editable=true}}
-    {{/if}}    
+        {{editor journalNotes target="flags.gm-notes.notes" button=true owner=owner editable=true}}
+    {{/if}}
 </form>


### PR DESCRIPTION
Made some adjustments to make this v10 compatible.

1) Moved support of JournalEntries to their specific case - so now supported by all systems (as long as constructor is JournalEntry
2) Change move from note and move to journal page, so that it finds the current page and only updates this.  Not optimal, but it was the best I could think of, bar making GM notes per/page - which I think is overkill

Known faults:
With frantic alternate clicking on move-to-journal, move-to-note you will eventually beat the event cycle and the current page can't be located. In this scenario, the buttons for transferring to and from the journal/note will go away.  They will return if GM notes are reopened again.  No data is lost.

This version will not work in v9.  I've not tested the dnd5e specific functionality - not got a v10 dnd5e system and consider my knowledge of the Foundry dnd5e system to be too low and that it is a liability for me to test in that system.